### PR TITLE
Update gitlab admin user and password info

### DIFF
--- a/book/04-git-server/sections/gitlab.asc
+++ b/book/04-git-server/sections/gitlab.asc
@@ -24,7 +24,9 @@ For more information read the https://gitlab.com/gitlab-org/gitlab-foss/-/blob/m
 ==== Administration
 
 GitLab's administration interface is accessed over the web.
-Simply point your browser to the hostname or IP address where GitLab is installed, and log in as the `root` user. The password will depend on your installation type but by default, Omnibus GitLab automatically generates a password for and stores it to /etc/gitlab/initial_root_password for at least 24 hours. Follow the documentation for more details.
+Simply point your browser to the hostname or IP address where GitLab is installed, and log in as the `root` user.
+The password will depend on your installation type but by default, Omnibus GitLab automatically generates a password for and stores it to /etc/gitlab/initial_root_password for at least 24 hours.
+Follow the documentation for more details.
 After you've logged in, click the "`Admin area`" icon in the menu at the top right.
 
 [[gitlab_menu]]

--- a/book/04-git-server/sections/gitlab.asc
+++ b/book/04-git-server/sections/gitlab.asc
@@ -24,8 +24,7 @@ For more information read the https://gitlab.com/gitlab-org/gitlab-foss/-/blob/m
 ==== Administration
 
 GitLab's administration interface is accessed over the web.
-Simply point your browser to the hostname or IP address where GitLab is installed, and log in as the admin user.
-The default username is `admin@local.host`, and the default password is `5iveL!fe` (which you must change right away).
+Simply point your browser to the hostname or IP address where GitLab is installed, and log in as the `root` user. The password will depend on your installation type but by default, Omnibus GitLab automatically generates a password for and stores it to /etc/gitlab/initial_root_password for at least 24 hours. Follow the documentation for more details.
 After you've logged in, click the "`Admin area`" icon in the menu at the top right.
 
 [[gitlab_menu]]


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes
- Updated self-hosted gitlab admin user and password info.

## Context
The information about admin user and password for a new Gitlab installation was outdated, I have changed the information to reflect changes in the self hosted version of Gitlab.
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
